### PR TITLE
Add .r00 file extension for unrar

### DIFF
--- a/deluge_simpleextractor/core.py
+++ b/deluge_simpleextractor/core.py
@@ -65,6 +65,7 @@ else:
 
     EXTRACT_COMMANDS = {
         '.rar': ['unrar', 'x -o+ -y'],
+        '.r00': ['unrar', 'x -o+ -y'],
         '.tar': ['tar', '-xf'],
         '.zip': ['unzip', ''],
         '.tar.gz': ['tar', '-xzf'],


### PR DESCRIPTION
For rar files in parts, sometimes the first rar file does not have the extension .rar but .r00